### PR TITLE
build in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-alpine
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN set -x \
+    && apk add --no-cache --virtual .build-dependencies \
+        git \
+        autoconf \
+        g++ \
+        make \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del .build-dependencies
+
+COPY . .
+
+CMD [ "python", "./__init__.py" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tldextract==2.2.0
 tabulate==0.8.2
 numpy>=1.12.1
-aiohttp>=1.0.5
+aiohttp>=1.0.5,<1.1.0
 discord.py==0.16.12
 mysql-connector>=2.1.6


### PR DESCRIPTION
built
```
Successfully tagged bernard
```

and running
```
$ docker run --rm -v ${PWD}/config.json:/app/config.json -it bernard
2019-04-23 17:42:49 __main__ INFO -> Attempting to start. I can't promise you I will work but I can sure try.
```

requirements.txt change fixes this error during python dep installation...
```
discord-py 0.16.12 has requirement aiohttp<1.1.0,>=1.0.0, but you'll have aiohttp 3.5.4 which is incompatible.
```